### PR TITLE
chore: fix abi helper, fix validate event

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "build": "tsc --skipLibCheck",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "format": "prettier --write \"**/*.{ts,js,json,md}\""
+    "format": "prettier --write \"**/*.{ts,js,json,md}\"",
+    "postinstall": "patch-package"
   },
   "dependencies": {
-    "abi-wan-kanabi": "^2.2.4",
+    "abi-wan-kanabi": "2.2.4",
     "pg": "^8.11.0",
     "starknet": "^7.1.0"
   },
@@ -23,6 +24,7 @@
     "eslint-plugin-prettier": "^5.4.0",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.2",
+    "patch-package": "^8.0.0",
     "prettier": "^3.5.3",
     "typescript": "^5.0.0"
   },

--- a/patches/abi-wan-kanabi+2.2.4.patch
+++ b/patches/abi-wan-kanabi+2.2.4.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/abi-wan-kanabi/dist/config.d.ts b/node_modules/abi-wan-kanabi/dist/config.d.ts
+index dde2892..18d4b47 100644
+--- a/node_modules/abi-wan-kanabi/dist/config.d.ts
++++ b/node_modules/abi-wan-kanabi/dist/config.d.ts
+@@ -161,7 +161,7 @@ export type ResolvedConfig<OptionT = any, ResultT = any, ErrorT = any> = {
+     } ? type : DefaultConfig<OptionT>['InvokeFunctionResponse'];
+ };
+ export type DefaultConfig<OptionT = any, ResultT = any, ErrorT = any> = {
+-    AddressType: string;
++    AddressType: bigint;
+     ClassHashType: string;
+     FeltType: number | bigint | string;
+     BigIntType: number | bigint;

--- a/src/index.ts
+++ b/src/index.ts
@@ -225,9 +225,8 @@ export class StarknetIndexer {
       if (item.type !== 'event') continue;
 
       const fullName = item.name;
-      const cleanEventName = fullName.split('::').pop() || '';
 
-      if (cleanEventName.toLowerCase() === eventName.toLowerCase()) {
+      if (fullName.toLowerCase() === eventName.toLowerCase()) {
         this.logger.info(`Found event "${eventName}" in contract ${contractAddress}`);
         return true;
       }


### PR DESCRIPTION
## Description

- The AddressType is currently detected as a "string", but parseEvents parses it into a bigint. As a result, the stormbit-indexer incorrectly infers the type for any ContractAddress in the ABI. It should be detected as a bigint, but it’s currently being treated as a string.
