### PR TITLE
chore: add more log and fix process queue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -638,14 +638,17 @@ export class StarknetIndexer {
     const maxBlockNumber = Math.max(...blocksToProcess.map((block) => block.block_number));
     const minBlockNumber = Math.min(...blocksToProcess.map((block) => block.block_number));
 
-    for (const block of blocksToProcess) {
-      try {
-        this.logger.info(`[${TAG}] Processing queued block #${block.block_number}`);
-        await this.processHistoricalBlocks(minBlockNumber, maxBlockNumber);
-        this.logger.info(`[${TAG}] Successfully processed queued block #${block.block_number}`);
-      } catch (error) {
-        this.logger.error(`[${TAG}] Error processing queued block ${block.block_number}:`, error);
-      }
+    try {
+      this.logger.info(`[${TAG}] Processing queued blocks ${minBlockNumber} to ${maxBlockNumber}`);
+      await this.processHistoricalBlocks(minBlockNumber, maxBlockNumber);
+      this.logger.info(
+        `[${TAG}] Successfully processed queued blocks ${minBlockNumber} to ${maxBlockNumber}`
+      );
+    } catch (error) {
+      this.logger.error(
+        `[${TAG}] Error processing queued blocks ${minBlockNumber} to ${maxBlockNumber}:`,
+        error
+      );
     }
   }
 


### PR DESCRIPTION
## Changes

- Added more log for performance
- Move ```await this.processBlockQueue();``` out of ```processHistorical``` condition

## Important

- [processBlockQueue] Replace ```processNewHead``` logic with ```processHistoricalBlocks```. The reason is that ```processNewHead``` updates the cursor and  ```processBlockQueue``` runs in parallel with ```onNewHeads```, which can lead to a race condition where ```processQueue``` updates the cursor after ```onNewHeads``` has already updated it (since anything in blockQueue can be considered as historical block because it's old so might as well use ```processHistoricalBlocks``` to process the whole queue in batch)