### PR TITLE
Fix block events and ws connection

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -930,7 +930,7 @@ export class StarknetIndexer {
   private async withExponentialBackoff<T>(
     operation: string,
     fn: () => Promise<T>,
-    maxRetries: number = 3,
+    maxRetries: number = 5,
     initialDelay: number = 500
   ): Promise<T | undefined> {
     let retries = 0;


### PR DESCRIPTION
## Description

- A new block is unlikely to have zero events. Sometimes, the RPC returns an empty list of events when processing a new head — this is likely because the RPC hasn’t fully indexed the events yet. Adding a retry mechanism to counter this.

- Sometimes, the WebSocket connection suddenly drops and reconnects, but no new blocks come in afterward. Add a wait-for-connection step before re-subscribing to ensure the connection is fully re-established.
