### PR TITLE
chore: detect processed block

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import {
 import { Pool, PoolClient } from 'pg';
 import { EventToPrimitiveType } from './types/abi-wan-helpers';
 import { ExtractAbiEventNames } from 'abi-wan-kanabi/kanabi';
+import { groupConsecutiveBlocks } from './utils/blockUtils';
 
 export enum LogLevel {
   DEBUG = 'debug',
@@ -693,10 +694,16 @@ export class StarknetIndexer {
             this.logger.info(
               `[${TAG}] Inserted ${blocks.length} blocks in ${Date.now() - insertStart}ms`
             );
-
-            // Process events
             const eventsStart = Date.now();
-            await this.processBlockEvents(blockNumber, chunkEndBlock, client);
+
+            if (blocks.length < chunkSize) {
+              const blockRanges = groupConsecutiveBlocks(blocks.map((block) => block.block_number));
+              for (const range of blockRanges) {
+                await this.processBlockEvents(range.from, range.to, client);
+              }
+            } else {
+              await this.processBlockEvents(blockNumber, chunkEndBlock, client);
+            }
             this.logger.info(`[${TAG}] Events processed in ${Date.now() - eventsStart}ms`);
           } else {
             this.logger.info(

--- a/src/utils/blockUtils.ts
+++ b/src/utils/blockUtils.ts
@@ -1,0 +1,24 @@
+type BlockRange = { from: number; to: number };
+
+export const groupConsecutiveBlocks = (blocks: number[]): BlockRange[] => {
+  if (blocks.length === 0) return [];
+
+  const sorted = [...blocks].sort((a, b) => a - b);
+  const ranges: BlockRange[] = [];
+
+  let start = sorted[0];
+  let end = sorted[0];
+
+  for (let i = 1; i < sorted.length; i++) {
+    if (sorted[i] === end + 1) {
+      end = sorted[i];
+    } else {
+      ranges.push({ from: start, to: end });
+      start = sorted[i];
+      end = sorted[i];
+    }
+  }
+
+  ranges.push({ from: start, to: end });
+  return ranges;
+};


### PR DESCRIPTION
## Problem

When processing historical blocks, we might encounter scenarios where blocks are not processed in a continuous sequence. For example:

- Blocks 1-50 are processed, block 51 is missing, blocks 52-100 are processed
- Only block 51 is processed, but blocks 1-50 and 52-100 are missing

The current implementation processes events for the entire range (e.g., 1-100) even when only a subset of blocks needs processing, leading to unnecessary event processing and database operations.

## Solution
Added a new `groupConsecutiveBlocks` helper function that:
1. Takes an array of block numbers
2. Groups them into consecutive ranges
3. Returns an array of `BlockRange` objects with `from` and `to` properties

Example:
```typescript
// Input: [1, 2, 3, 5, 6, 8, 9, 10]
// Output: [
//   { from: 1, to: 3 },
//   { from: 5, to: 6 },
//   { from: 8, to: 10 }
// ]
```