### PR TITLE
feat: find starting block number by binary search (SS2-88)

### DIFF
--- a/src/core/__tests__/indexer.test.ts
+++ b/src/core/__tests__/indexer.test.ts
@@ -25,6 +25,7 @@ jest.mock('starknet', () => {
         on: jest.fn(),
       }),
       isConnected: jest.fn().mockReturnValue(true),
+      disconnect: jest.fn(),
     })),
   };
 });

--- a/src/types/indexer.ts
+++ b/src/types/indexer.ts
@@ -83,7 +83,7 @@ export interface IndexerConfig {
   database: DatabaseConfig;
 
   /** Block number to start indexing from, or 'latest' to start from current block */
-  startingBlockNumber: number | 'latest';
+  startingBlockNumber?: number | 'latest';
 
   /** Optional array of contract addresses to monitor for events */
   contractAddresses?: string[];

--- a/src/utils/__tests__/blockUtils.test.ts
+++ b/src/utils/__tests__/blockUtils.test.ts
@@ -1,0 +1,51 @@
+import { findContractDeploymentBlock } from '../blockUtils';
+import { RpcProvider } from 'starknet';
+
+describe('findContractDeploymentBlock', () => {
+  // Use public Starknet Sepolia RPC endpoint for testing
+  const provider = new RpcProvider({
+    nodeUrl: 'https://starknet-sepolia-rpc.publicnode.com',
+    specVersion: '0.8.1',
+  });
+
+  // Well-known contract on Sepolia testnet
+  const deployedContractAddress = '0x4718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d';
+
+  it('should find deployment block for an existing contract', async () => {
+    const deploymentBlock = await findContractDeploymentBlock(provider, deployedContractAddress);
+
+    expect(deploymentBlock).toBe(6379);
+    expect(typeof deploymentBlock).toBe('number');
+
+    // Verify the contract actually exists at the found block
+    const nonce = await provider.getNonceForAddress(deployedContractAddress, deploymentBlock);
+    expect(nonce).toBeDefined();
+  }, 30000); // Increase timeout for network calls
+
+  it('should throw error when contract is not deployed', async () => {
+    // Use an address that doesn't exist (random address)
+    const nonExistentAddress = '0x1234567890123456789012345678901234567890123456789012345678901234';
+
+    await expect(
+      findContractDeploymentBlock(provider, nonExistentAddress)
+    ).rejects.toThrow('Unable to find deployment block for contract');
+  }, 30000);
+
+  it('should efficiently find deployment block using binary search', async () => {
+    const rpcCallCount = { count: 0 };
+    const onRpcRequest = () => {
+      rpcCallCount.count++;
+    };
+
+    const deploymentBlock = await findContractDeploymentBlock(provider, deployedContractAddress, {
+      onRpcRequest,
+    });
+
+    expect(deploymentBlock).toBe(6379);
+    // Binary search should make O(log n) calls
+    // For a typical blockchain with thousands of blocks, should be reasonable
+    expect(rpcCallCount.count).toBeGreaterThan(0);
+    expect(rpcCallCount.count).toBeLessThan(50); // Should be much less than linear search
+  }, 30000);
+});
+

--- a/src/utils/blockUtils.ts
+++ b/src/utils/blockUtils.ts
@@ -62,11 +62,9 @@ export async function findContractDeploymentBlock(
     try {
       options.onRpcRequest?.();
       await provider.getNonceForAddress(contractAddress, mid);
-      console.log(`Found deployment block for ${contractAddress} at ${mid}`);
       foundBlock = mid;
       high = mid - 1;
     } catch (_error) {
-      console.log(`No deployment block found for ${contractAddress} at ${mid}`, _error);
       low = mid + 1;
     }
   }

--- a/src/utils/blockUtils.ts
+++ b/src/utils/blockUtils.ts
@@ -1,3 +1,5 @@
+import { BlockNumber, RpcProvider } from 'starknet';
+
 type BlockRange = { from: number; to: number };
 
 export const groupConsecutiveBlocks = (blocks: number[]): BlockRange[] => {
@@ -38,4 +40,40 @@ export async function parallelMap<T, R>(
   }
   await Promise.all(Array(concurrency).fill(0).map(worker));
   return results;
+}
+
+type FindDeploymentOptions = {
+  onRpcRequest?: () => void;
+};
+
+export async function findContractDeploymentBlock(
+  provider: RpcProvider,
+  contractAddress: string,
+  options: FindDeploymentOptions = {}
+): Promise<number> {
+  let low = 0;
+  let high = await provider.getBlockNumber();
+
+  let foundBlock: number | null = null;
+
+  while (low <= high) {
+    const mid = Math.floor((low + high) / 2);
+
+    try {
+      options.onRpcRequest?.();
+      await provider.getNonceForAddress(contractAddress, mid);
+      console.log(`Found deployment block for ${contractAddress} at ${mid}`);
+      foundBlock = mid;
+      high = mid - 1;
+    } catch (_error) {
+      console.log(`No deployment block found for ${contractAddress} at ${mid}`, _error);
+      low = mid + 1;
+    }
+  }
+
+  if (foundBlock === null) {
+    throw new Error(`Unable to find deployment block for contract ${contractAddress}`);
+  }
+
+  return foundBlock;
 }


### PR DESCRIPTION
## Description of change

- Made startingBlockNumber optional in IndexerConfig
- Added findContractDeploymentBlock() utility using binary search with starknet_getNonce
- Updated indexer to resolve the starting block from contract addresses when startingBlockNumber is not provided
- Finds the earliest deployment block across all configured contracts
- Added logging and performance timing for deployment block resolution


## Issue number

Closes #44 
 
## Type of change (delete irrelevant types)

- New feature (non-breaking change which adds functionality)

## Checklist:

- [x] I have tested locally and linked a screen recording with this PR
- [x] I have adhered to clean code conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
